### PR TITLE
feat: add MCP tool definitions and handlers for SSH operations

### DIFF
--- a/ssh-control-mcp/CHANGELOG.md
+++ b/ssh-control-mcp/CHANGELOG.md
@@ -5,18 +5,45 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.3] - 2025-10-04
 
 ### Added
 
-- Graceful shutdown support via stopServer() function
+- MCP tool definitions for all 6 SSH operations (src/mcp/tools.ts)
+- Tool request handlers with Zod schema validation (src/mcp/handlers.ts)
+- ssh_execute: one-off command execution without persistent session
+- ssh_session_create: create persistent SSH sessions (interactive/background)
+- ssh_session_execute: execute commands in existing sessions
+- ssh_session_list: list all active sessions with metadata
+- ssh_session_close: close and cleanup sessions
+- ssh_session_output: retrieve buffered output (max 50,000 lines per request)
+- Comprehensive test coverage for tools and handlers (54 tests)
+
+### Security
+
+- Input validation via Zod schemas for all MCP tool parameters
+- Output line limit (50,000) prevents memory exhaustion from accidental large requests
+- Session metadata filtering excludes sensitive data (environmentVars, commandHistory, workingDirectory)
+- Port range validation (1-65535) and timeout constraints
+
+## [0.1.2] - 2025-10-01
+
+### Added
+
+- MCP server initialization with stdio transport
+- Tool registration framework (ready for tool definitions)
+- Integration with @modelcontextprotocol/sdk v1.18.x
+- Comprehensive MCP server test suite (tests/mcp/server.test.ts)
+- Error handling for transport connection failures
+- JSDoc documentation for all MCP server functions
+- - Graceful shutdown support via stopServer() function
 - Signal handlers for SIGTERM and SIGINT (optional, via startServer options)
 - StartServerOptions interface for configuration
 - Comprehensive tests for shutdown lifecycle (26 MCP server tests total)
 - Defensive parameter validation across SSH module (PersistentSession and SSHConnectionManager)
 - ConnectionPool class for SSH connection reuse and lifecycle management (24 tests)
 - Comprehensive test suite for connection pooling with defensive coding tests
-
+  
 ### Changed
 
 - SSH module now uses centralized error constants for consistent error messaging
@@ -33,17 +60,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SSHConnectionManager now uses ConnectionPool internally for connection management
 - All existing tests continue to pass (110 total tests)
 - Public API remains backward compatible
-
-## [0.1.2] - 2025-10-01
-
-### Added
-
-- MCP server initialization with stdio transport
-- Tool registration framework (ready for tool definitions)
-- Integration with @modelcontextprotocol/sdk v1.18.x
-- Comprehensive MCP server test suite (tests/mcp/server.test.ts)
-- Error handling for transport connection failures
-- JSDoc documentation for all MCP server functions
 
 ## [0.1.1] - 2025-10-01
 

--- a/ssh-control-mcp/src/mcp/handlers.ts
+++ b/ssh-control-mcp/src/mcp/handlers.ts
@@ -1,0 +1,179 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { SSHConnectionManager } from '../ssh/manager.js';
+import {
+  tools,
+  SshExecuteArgsSchema,
+  SshSessionCreateArgsSchema,
+  SshSessionExecuteArgsSchema,
+  SshSessionListArgsSchema,
+  SshSessionCloseArgsSchema,
+  SshSessionOutputArgsSchema,
+  type SshExecuteArgs,
+  type SshSessionCreateArgs,
+  type SshSessionExecuteArgs,
+  type SshSessionListArgs,
+  type SshSessionCloseArgs,
+  type SshSessionOutputArgs,
+} from './tools.js';
+
+/**
+ * Register tool handlers on the MCP server
+ *
+ * @param server - The MCP server instance
+ * @param manager - The SSH connection manager instance
+ */
+export function registerToolHandlers(server: Server, manager: SSHConnectionManager): void {
+  // Register tools/list handler
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    return {
+      tools: tools.map(tool => ({
+        name: tool.name,
+        description: tool.description,
+        inputSchema: tool.inputSchema,
+      })),
+    };
+  });
+
+  // Register tools/call handler
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
+
+    switch (name) {
+      case 'ssh_execute': {
+        const validatedArgs = SshExecuteArgsSchema.parse(args) as SshExecuteArgs;
+        const result = await manager.executeCommand(
+          validatedArgs.host,
+          validatedArgs.username,
+          validatedArgs.privateKeyPath,
+          validatedArgs.command,
+          validatedArgs.port,
+          validatedArgs.timeout
+        );
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'ssh_session_create': {
+        const validatedArgs = SshSessionCreateArgsSchema.parse(args) as SshSessionCreateArgs;
+        const session = await manager.createSession(
+          validatedArgs.sessionId,
+          validatedArgs.host,
+          validatedArgs.username,
+          validatedArgs.type,
+          validatedArgs.privateKeyPath,
+          validatedArgs.port,
+          validatedArgs.mode,
+          undefined, // timeoutMs - use default
+          validatedArgs.shellType
+        );
+
+        const sessionInfo = session.getSessionInfo();
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                sessionId: sessionInfo.sessionId,
+                target: sessionInfo.target,
+                username: sessionInfo.username,
+                type: sessionInfo.type,
+                mode: sessionInfo.mode,
+                port: sessionInfo.port,
+                isActive: sessionInfo.isActive,
+                createdAt: sessionInfo.createdAt,
+              }, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'ssh_session_execute': {
+        const validatedArgs = SshSessionExecuteArgsSchema.parse(args) as SshSessionExecuteArgs;
+        const result = await manager.executeInSession(
+          validatedArgs.sessionId,
+          validatedArgs.command,
+          validatedArgs.timeout
+        );
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'ssh_session_list': {
+        SshSessionListArgsSchema.parse(args); // Validate (even though empty)
+        const sessions = manager.listSessions();
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(sessions.map(session => ({
+                sessionId: session.sessionId,
+                target: session.target,
+                username: session.username,
+                type: session.type,
+                mode: session.mode,
+                port: session.port,
+                isActive: session.isActive,
+                createdAt: session.createdAt,
+                lastActivity: session.lastActivity,
+              })), null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'ssh_session_close': {
+        const validatedArgs = SshSessionCloseArgsSchema.parse(args) as SshSessionCloseArgs;
+        const success = await manager.closeSession(validatedArgs.sessionId);
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({ success }, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'ssh_session_output': {
+        const validatedArgs = SshSessionOutputArgsSchema.parse(args) as SshSessionOutputArgs;
+        const output = manager.getSessionOutput(
+          validatedArgs.sessionId,
+          validatedArgs.lines,
+          validatedArgs.clear
+        );
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({ output }, null, 2),
+            },
+          ],
+        };
+      }
+
+      default:
+        throw new Error(`Unknown tool: ${name}`);
+    }
+  });
+}

--- a/ssh-control-mcp/src/mcp/server.ts
+++ b/ssh-control-mcp/src/mcp/server.ts
@@ -2,10 +2,13 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { NULL_OR_UNDEFINED_ARGUMENTS_ERROR, FAILED_TO_START_MCP_SERVER_ERROR } from '../constants.js';
 import pkg from '../../package.json' with { type: 'json' };
+import { SSHConnectionManager } from '../ssh/manager.js';
+import { registerToolHandlers } from './handlers.js';
 
 /**
  * Create and configure the MCP server instance
  *
+ * @param manager - Optional SSH connection manager instance. If not provided, a new one will be created.
  * @returns A configured MCP server instance ready to be started
  *
  * @example
@@ -14,7 +17,7 @@ import pkg from '../../package.json' with { type: 'json' };
  * await startServer(server);
  * ```
  */
-export function createServer(): Server {
+export function createServer(manager?: SSHConnectionManager): Server {
   const server = new Server(
     {
       name: 'ssh-control-mcp',
@@ -27,8 +30,9 @@ export function createServer(): Server {
     }
   );
 
-  // Tool registration framework placeholder
-  // Tools will be registered in subsequent issues
+  // Register tool handlers with SSH connection manager
+  const sshManager = manager || new SSHConnectionManager();
+  registerToolHandlers(server, sshManager);
 
   return server;
 }

--- a/ssh-control-mcp/src/mcp/tools.ts
+++ b/ssh-control-mcp/src/mcp/tools.ts
@@ -1,0 +1,158 @@
+import { z } from 'zod';
+
+/**
+ * Zod schema for ssh_execute tool parameters
+ */
+export const SshExecuteArgsSchema = z.object({
+  host: z.string().min(1).describe('The SSH host to connect to'),
+  username: z.string().min(1).describe('The username for SSH authentication'),
+  privateKeyPath: z.string().min(1).describe('Path to the private key file for authentication'),
+  command: z.string().min(1).describe('The command to execute on the remote host'),
+  port: z.number().int().min(1).max(65535).optional().default(22).describe('The SSH port (default: 22)'),
+  timeout: z.number().int().positive().optional().default(30000).describe('Command timeout in milliseconds (default: 30000)'),
+});
+
+/**
+ * Zod schema for ssh_session_create tool parameters
+ */
+export const SshSessionCreateArgsSchema = z.object({
+  sessionId: z.string().min(1).describe('Unique identifier for the session'),
+  host: z.string().min(1).describe('The SSH host to connect to'),
+  username: z.string().min(1).describe('The username for SSH authentication'),
+  privateKeyPath: z.string().min(1).describe('Path to the private key file for authentication'),
+  type: z.enum(['interactive', 'background']).describe('Session type: interactive for command-response, background for continuous output'),
+  port: z.number().int().min(1).max(65535).optional().default(22).describe('The SSH port (default: 22)'),
+  mode: z.enum(['normal', 'raw']).optional().default('normal').describe('Session mode: normal for structured output, raw for direct stream'),
+  shellType: z.enum(['bash', 'sh', 'powershell', 'cmd']).optional().default('bash').describe('The shell type to use (default: bash)'),
+});
+
+/**
+ * Zod schema for ssh_session_execute tool parameters
+ */
+export const SshSessionExecuteArgsSchema = z.object({
+  sessionId: z.string().min(1).describe('The session ID to execute the command in'),
+  command: z.string().min(1).describe('The command to execute in the session'),
+  timeout: z.number().int().positive().optional().default(30000).describe('Command timeout in milliseconds (default: 30000)'),
+});
+
+/**
+ * Zod schema for ssh_session_list tool parameters
+ */
+export const SshSessionListArgsSchema = z.object({});
+
+/**
+ * Zod schema for ssh_session_close tool parameters
+ */
+export const SshSessionCloseArgsSchema = z.object({
+  sessionId: z.string().min(1).describe('The session ID to close'),
+});
+
+/**
+ * Zod schema for ssh_session_output tool parameters
+ */
+export const SshSessionOutputArgsSchema = z.object({
+  sessionId: z.string().min(1).describe('The session ID to get output from'),
+  lines: z.number().int().positive().max(50000).optional().describe('Number of lines to retrieve (max: 50000, default: all)'),
+  clear: z.boolean().optional().default(false).describe('Whether to clear the buffer after retrieving (default: false)'),
+});
+
+/**
+ * Type definitions for tool arguments
+ */
+export type SshExecuteArgs = z.infer<typeof SshExecuteArgsSchema>;
+export type SshSessionCreateArgs = z.infer<typeof SshSessionCreateArgsSchema>;
+export type SshSessionExecuteArgs = z.infer<typeof SshSessionExecuteArgsSchema>;
+export type SshSessionListArgs = z.infer<typeof SshSessionListArgsSchema>;
+export type SshSessionCloseArgs = z.infer<typeof SshSessionCloseArgsSchema>;
+export type SshSessionOutputArgs = z.infer<typeof SshSessionOutputArgsSchema>;
+
+/**
+ * Helper function to convert Zod schema to JSON Schema format for MCP
+ */
+function zodToJsonSchema(schema: z.ZodObject<any>): { type: 'object'; properties: Record<string, any>; required?: string[] } {
+  const shape = schema.shape;
+  const properties: Record<string, any> = {};
+  const required: string[] = [];
+
+  for (const [key, value] of Object.entries(shape)) {
+    let zodType = value as z.ZodTypeAny;
+    let isRequired = true;
+
+    // Extract description from Zod schema
+    const description = (zodType as any)._def?.description || '';
+
+    // Unwrap optional and default wrappers to get the inner type
+    // Need to unwrap recursively in case of nested wrappers (e.g., ZodDefault containing ZodOptional)
+    while (zodType instanceof z.ZodOptional || zodType instanceof z.ZodDefault) {
+      isRequired = false;
+      zodType = (zodType as any)._def.innerType;
+    }
+
+    // Determine JSON Schema type based on the inner type
+    if (zodType instanceof z.ZodString) {
+      properties[key] = { type: 'string', description };
+    } else if (zodType instanceof z.ZodNumber) {
+      properties[key] = { type: 'number', description };
+    } else if (zodType instanceof z.ZodBoolean) {
+      properties[key] = { type: 'boolean', description };
+    } else if (zodType instanceof z.ZodEnum) {
+      properties[key] = {
+        type: 'string',
+        enum: (zodType as any)._def.values,
+        description
+      };
+    }
+
+    // Add to required array if not optional
+    if (isRequired) {
+      required.push(key);
+    }
+  }
+
+  return {
+    type: 'object',
+    properties,
+    ...(required.length > 0 ? { required } : {})
+  };
+}
+
+/**
+ * MCP tool definitions for SSH operations
+ */
+export const tools = [
+  {
+    name: 'ssh_execute',
+    description: 'Execute a single SSH command on a remote host without creating a persistent session. Use this for one-off commands that complete quickly.',
+    inputSchema: zodToJsonSchema(SshExecuteArgsSchema),
+  },
+  {
+    name: 'ssh_session_create',
+    description: 'Create a persistent SSH session for executing multiple commands. Interactive sessions wait for each command to complete. Background sessions queue commands and buffer output.',
+    inputSchema: zodToJsonSchema(SshSessionCreateArgsSchema),
+  },
+  {
+    name: 'ssh_session_execute',
+    description: 'Execute a command in an existing SSH session. The session must have been created with ssh_session_create first.',
+    inputSchema: zodToJsonSchema(SshSessionExecuteArgsSchema),
+  },
+  {
+    name: 'ssh_session_list',
+    description: 'List all active SSH sessions with their metadata including session ID, host, type, and status.',
+    inputSchema: zodToJsonSchema(SshSessionListArgsSchema),
+  },
+  {
+    name: 'ssh_session_close',
+    description: 'Close a specific SSH session and clean up its resources. Returns true if the session was closed, false if it was not found.',
+    inputSchema: zodToJsonSchema(SshSessionCloseArgsSchema),
+  },
+  {
+    name: 'ssh_session_output',
+    description: 'Get buffered output from a background SSH session. Optionally retrieve a specific number of lines and clear the buffer.',
+    inputSchema: zodToJsonSchema(SshSessionOutputArgsSchema),
+  },
+] as const;
+
+/**
+ * Tool names type for type safety
+ */
+export type ToolName = typeof tools[number]['name'];

--- a/ssh-control-mcp/tests/mcp/handlers.test.ts
+++ b/ssh-control-mcp/tests/mcp/handlers.test.ts
@@ -1,0 +1,412 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { SSHConnectionManager } from '../../src/ssh/manager.js';
+import { registerToolHandlers } from '../../src/mcp/handlers.js';
+import { CommandResult, SessionMetadata } from '../../src/ssh/types.js';
+
+vi.mock('@modelcontextprotocol/sdk/server/index.js');
+vi.mock('../../src/ssh/manager.js');
+
+describe('MCP Handlers', () => {
+  let mockServer: any;
+  let mockManager: any;
+  let listToolsHandler: any;
+  let callToolHandler: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Create mock server with handler registration tracking
+    mockServer = {
+      setRequestHandler: vi.fn((schema, handler) => {
+        if (schema.shape?.method?._def?.value === 'tools/list') {
+          listToolsHandler = handler;
+        } else if (schema.shape?.method?._def?.value === 'tools/call') {
+          callToolHandler = handler;
+        }
+      }),
+    };
+
+    // Create mock SSH manager
+    mockManager = {
+      executeCommand: vi.fn(),
+      createSession: vi.fn(),
+      executeInSession: vi.fn(),
+      listSessions: vi.fn(),
+      closeSession: vi.fn(),
+      getSessionOutput: vi.fn(),
+    };
+
+    registerToolHandlers(mockServer, mockManager);
+  });
+
+  describe('registerToolHandlers', () => {
+    it('should register tools/list handler', () => {
+      expect(mockServer.setRequestHandler).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.any(Function)
+      );
+      expect(listToolsHandler).toBeDefined();
+    });
+
+    it('should register tools/call handler', () => {
+      expect(mockServer.setRequestHandler).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.any(Function)
+      );
+      expect(callToolHandler).toBeDefined();
+    });
+  });
+
+  describe('tools/list handler', () => {
+    it('should return all 6 tools', async () => {
+      const result = await listToolsHandler({});
+
+      expect(result.tools).toHaveLength(6);
+    });
+
+    it('should return tools with correct structure', async () => {
+      const result = await listToolsHandler({});
+
+      result.tools.forEach((tool: any) => {
+        expect(tool).toHaveProperty('name');
+        expect(tool).toHaveProperty('description');
+        expect(tool).toHaveProperty('inputSchema');
+        expect(tool.inputSchema).toHaveProperty('type', 'object');
+        expect(tool.inputSchema).toHaveProperty('properties');
+      });
+    });
+
+    it('should include all required tools', async () => {
+      const result = await listToolsHandler({});
+      const toolNames = result.tools.map((t: any) => t.name);
+
+      expect(toolNames).toContain('ssh_execute');
+      expect(toolNames).toContain('ssh_session_create');
+      expect(toolNames).toContain('ssh_session_execute');
+      expect(toolNames).toContain('ssh_session_list');
+      expect(toolNames).toContain('ssh_session_close');
+      expect(toolNames).toContain('ssh_session_output');
+    });
+  });
+
+  describe('tools/call handler - ssh_execute', () => {
+    it('should call manager.executeCommand with correct parameters', async () => {
+      const mockResult: CommandResult = {
+        stdout: 'output',
+        stderr: '',
+        code: 0,
+        signal: null,
+      };
+      mockManager.executeCommand.mockResolvedValue(mockResult);
+
+      const request = {
+        params: {
+          name: 'ssh_execute',
+          arguments: {
+            host: 'example.com',
+            username: 'user',
+            privateKeyPath: '/path/to/key',
+            command: 'ls -la',
+          },
+        },
+      };
+
+      await callToolHandler(request);
+
+      expect(mockManager.executeCommand).toHaveBeenCalledWith(
+        'example.com',
+        'user',
+        '/path/to/key',
+        'ls -la',
+        22, // default port
+        30000 // default timeout
+      );
+    });
+
+    it('should return command result as JSON', async () => {
+      const mockResult: CommandResult = {
+        stdout: 'test output',
+        stderr: '',
+        code: 0,
+        signal: null,
+      };
+      mockManager.executeCommand.mockResolvedValue(mockResult);
+
+      const request = {
+        params: {
+          name: 'ssh_execute',
+          arguments: {
+            host: 'example.com',
+            username: 'user',
+            privateKeyPath: '/path/to/key',
+            command: 'echo test',
+          },
+        },
+      };
+
+      const result = await callToolHandler(request);
+
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0].type).toBe('text');
+      const parsedContent = JSON.parse(result.content[0].text);
+      expect(parsedContent).toEqual(mockResult);
+    });
+  });
+
+  describe('tools/call handler - ssh_session_create', () => {
+    it('should call manager.createSession with correct parameters', async () => {
+      const mockSession = {
+        getSessionInfo: vi.fn().mockReturnValue({
+          sessionId: 'test-session',
+          target: 'example.com',
+          username: 'user',
+          type: 'interactive',
+          mode: 'normal',
+          port: 22,
+          isActive: true,
+          createdAt: new Date(),
+        }),
+      };
+      mockManager.createSession.mockResolvedValue(mockSession);
+
+      const request = {
+        params: {
+          name: 'ssh_session_create',
+          arguments: {
+            sessionId: 'test-session',
+            host: 'example.com',
+            username: 'user',
+            privateKeyPath: '/path/to/key',
+            type: 'interactive',
+          },
+        },
+      };
+
+      await callToolHandler(request);
+
+      expect(mockManager.createSession).toHaveBeenCalledWith(
+        'test-session',
+        'example.com',
+        'user',
+        'interactive',
+        '/path/to/key',
+        22,
+        'normal',
+        undefined,
+        'bash'
+      );
+    });
+
+    it('should return session info as JSON', async () => {
+      const mockSessionInfo = {
+        sessionId: 'test-session',
+        target: 'example.com',
+        username: 'user',
+        type: 'interactive' as const,
+        mode: 'normal' as const,
+        port: 22,
+        isActive: true,
+        createdAt: new Date('2024-01-01'),
+      };
+
+      const mockSession = {
+        getSessionInfo: vi.fn().mockReturnValue(mockSessionInfo),
+      };
+      mockManager.createSession.mockResolvedValue(mockSession);
+
+      const request = {
+        params: {
+          name: 'ssh_session_create',
+          arguments: {
+            sessionId: 'test-session',
+            host: 'example.com',
+            username: 'user',
+            privateKeyPath: '/path/to/key',
+            type: 'interactive',
+          },
+        },
+      };
+
+      const result = await callToolHandler(request);
+
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0].type).toBe('text');
+      const parsedContent = JSON.parse(result.content[0].text);
+      expect(parsedContent.sessionId).toBe('test-session');
+    });
+  });
+
+  describe('tools/call handler - ssh_session_execute', () => {
+    it('should call manager.executeInSession with correct parameters', async () => {
+      const mockResult: CommandResult = {
+        stdout: 'output',
+        stderr: '',
+        code: 0,
+        signal: null,
+      };
+      mockManager.executeInSession.mockResolvedValue(mockResult);
+
+      const request = {
+        params: {
+          name: 'ssh_session_execute',
+          arguments: {
+            sessionId: 'test-session',
+            command: 'pwd',
+          },
+        },
+      };
+
+      await callToolHandler(request);
+
+      expect(mockManager.executeInSession).toHaveBeenCalledWith(
+        'test-session',
+        'pwd',
+        30000
+      );
+    });
+  });
+
+  describe('tools/call handler - ssh_session_list', () => {
+    it('should call manager.listSessions', async () => {
+      const mockSessions: SessionMetadata[] = [
+        {
+          sessionId: 'session-1',
+          target: 'host1.com',
+          username: 'user1',
+          type: 'interactive',
+          mode: 'normal',
+          createdAt: new Date(),
+          lastActivity: new Date(),
+          port: 22,
+          workingDirectory: '~',
+          environmentVars: new Map(),
+          isActive: true,
+          commandHistory: [],
+        },
+      ];
+      mockManager.listSessions.mockReturnValue(mockSessions);
+
+      const request = {
+        params: {
+          name: 'ssh_session_list',
+          arguments: {},
+        },
+      };
+
+      const result = await callToolHandler(request);
+
+      expect(mockManager.listSessions).toHaveBeenCalled();
+      expect(result.content).toHaveLength(1);
+      const parsedContent = JSON.parse(result.content[0].text);
+      expect(parsedContent).toHaveLength(1);
+      expect(parsedContent[0].sessionId).toBe('session-1');
+    });
+  });
+
+  describe('tools/call handler - ssh_session_close', () => {
+    it('should call manager.closeSession with correct sessionId', async () => {
+      mockManager.closeSession.mockResolvedValue(true);
+
+      const request = {
+        params: {
+          name: 'ssh_session_close',
+          arguments: {
+            sessionId: 'test-session',
+          },
+        },
+      };
+
+      await callToolHandler(request);
+
+      expect(mockManager.closeSession).toHaveBeenCalledWith('test-session');
+    });
+
+    it('should return success status', async () => {
+      mockManager.closeSession.mockResolvedValue(true);
+
+      const request = {
+        params: {
+          name: 'ssh_session_close',
+          arguments: {
+            sessionId: 'test-session',
+          },
+        },
+      };
+
+      const result = await callToolHandler(request);
+      const parsedContent = JSON.parse(result.content[0].text);
+      expect(parsedContent.success).toBe(true);
+    });
+  });
+
+  describe('tools/call handler - ssh_session_output', () => {
+    it('should call manager.getSessionOutput with correct parameters', async () => {
+      mockManager.getSessionOutput.mockReturnValue(['line1', 'line2']);
+
+      const request = {
+        params: {
+          name: 'ssh_session_output',
+          arguments: {
+            sessionId: 'test-session',
+            lines: 10,
+            clear: true,
+          },
+        },
+      };
+
+      await callToolHandler(request);
+
+      expect(mockManager.getSessionOutput).toHaveBeenCalledWith(
+        'test-session',
+        10,
+        true
+      );
+    });
+
+    it('should return output as JSON array', async () => {
+      const mockOutput = ['line1', 'line2', 'line3'];
+      mockManager.getSessionOutput.mockReturnValue(mockOutput);
+
+      const request = {
+        params: {
+          name: 'ssh_session_output',
+          arguments: {
+            sessionId: 'test-session',
+          },
+        },
+      };
+
+      const result = await callToolHandler(request);
+      const parsedContent = JSON.parse(result.content[0].text);
+      expect(parsedContent.output).toEqual(mockOutput);
+    });
+  });
+
+  describe('tools/call handler - error cases', () => {
+    it('should throw error for unknown tool', async () => {
+      const request = {
+        params: {
+          name: 'unknown_tool',
+          arguments: {},
+        },
+      };
+
+      await expect(callToolHandler(request)).rejects.toThrow('Unknown tool: unknown_tool');
+    });
+
+    it('should throw validation error for invalid arguments', async () => {
+      const request = {
+        params: {
+          name: 'ssh_execute',
+          arguments: {
+            // Missing required fields
+            host: 'example.com',
+          },
+        },
+      };
+
+      await expect(callToolHandler(request)).rejects.toThrow();
+    });
+  });
+});

--- a/ssh-control-mcp/tests/mcp/server.test.ts
+++ b/ssh-control-mcp/tests/mcp/server.test.ts
@@ -108,6 +108,7 @@ describe('MCP Server', () => {
     it('should support complete startup flow', async () => {
       const mockServer = {
         connect: vi.fn().mockResolvedValue(undefined),
+        setRequestHandler: vi.fn(),
       } as any;
       const mockTransport = {};
 
@@ -120,6 +121,7 @@ describe('MCP Server', () => {
       expect(Server).toHaveBeenCalledTimes(1);
       expect(StdioServerTransport).toHaveBeenCalledTimes(1);
       expect(mockServer.connect).toHaveBeenCalledWith(mockTransport);
+      expect(mockServer.setRequestHandler).toHaveBeenCalled();
     });
   });
 
@@ -181,6 +183,7 @@ describe('MCP Server', () => {
       const mockServer = {
         connect: vi.fn().mockResolvedValue(undefined),
         close: vi.fn().mockResolvedValue(undefined),
+        setRequestHandler: vi.fn(),
       } as any;
 
       vi.mocked(Server).mockReturnValue(mockServer as any);

--- a/ssh-control-mcp/tests/mcp/tools.test.ts
+++ b/ssh-control-mcp/tests/mcp/tools.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect } from 'vitest';
+import {
+  tools,
+  SshExecuteArgsSchema,
+  SshSessionCreateArgsSchema,
+  SshSessionExecuteArgsSchema,
+  SshSessionListArgsSchema,
+  SshSessionCloseArgsSchema,
+  SshSessionOutputArgsSchema,
+} from '../../src/mcp/tools.js';
+
+describe('MCP Tools', () => {
+  describe('tools array', () => {
+    it('should export 6 tools', () => {
+      expect(tools).toHaveLength(6);
+    });
+
+    it('should have unique tool names', () => {
+      const names = tools.map(t => t.name);
+      const uniqueNames = new Set(names);
+      expect(uniqueNames.size).toBe(names.length);
+    });
+
+    it('should have all required tools', () => {
+      const names = tools.map(t => t.name);
+      expect(names).toContain('ssh_execute');
+      expect(names).toContain('ssh_session_create');
+      expect(names).toContain('ssh_session_execute');
+      expect(names).toContain('ssh_session_list');
+      expect(names).toContain('ssh_session_close');
+      expect(names).toContain('ssh_session_output');
+    });
+
+    it('should have description for each tool', () => {
+      tools.forEach(tool => {
+        expect(tool.description).toBeDefined();
+        expect(typeof tool.description).toBe('string');
+        expect(tool.description.length).toBeGreaterThan(0);
+      });
+    });
+
+    it('should have inputSchema for each tool', () => {
+      tools.forEach(tool => {
+        expect(tool.inputSchema).toBeDefined();
+        expect(tool.inputSchema.type).toBe('object');
+        expect(tool.inputSchema.properties).toBeDefined();
+      });
+    });
+  });
+
+  describe('ssh_execute tool', () => {
+    const sshExecute = tools.find(t => t.name === 'ssh_execute')!;
+
+    it('should have correct structure', () => {
+      expect(sshExecute.name).toBe('ssh_execute');
+      expect(sshExecute.inputSchema.type).toBe('object');
+      expect(sshExecute.inputSchema.properties).toBeDefined();
+    });
+
+    it('should have required parameters', () => {
+      expect(sshExecute.inputSchema.required).toContain('host');
+      expect(sshExecute.inputSchema.required).toContain('username');
+      expect(sshExecute.inputSchema.required).toContain('privateKeyPath');
+      expect(sshExecute.inputSchema.required).toContain('command');
+    });
+
+    it('should have optional parameters', () => {
+      expect(sshExecute.inputSchema.properties.port).toBeDefined();
+      expect(sshExecute.inputSchema.properties.timeout).toBeDefined();
+      expect(sshExecute.inputSchema.required).not.toContain('port');
+      expect(sshExecute.inputSchema.required).not.toContain('timeout');
+    });
+
+    it('should validate valid arguments', () => {
+      const validArgs = {
+        host: 'example.com',
+        username: 'user',
+        privateKeyPath: '/path/to/key',
+        command: 'ls -la',
+      };
+      const result = SshExecuteArgsSchema.safeParse(validArgs);
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject missing required arguments', () => {
+      const invalidArgs = {
+        host: 'example.com',
+      };
+      const result = SshExecuteArgsSchema.safeParse(invalidArgs);
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject invalid port', () => {
+      const invalidArgs = {
+        host: 'example.com',
+        username: 'user',
+        privateKeyPath: '/path/to/key',
+        command: 'ls',
+        port: 70000,
+      };
+      const result = SshExecuteArgsSchema.safeParse(invalidArgs);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('ssh_session_create tool', () => {
+    const sessionCreate = tools.find(t => t.name === 'ssh_session_create')!;
+
+    it('should have correct structure', () => {
+      expect(sessionCreate.name).toBe('ssh_session_create');
+      expect(sessionCreate.inputSchema.type).toBe('object');
+    });
+
+    it('should have required parameters', () => {
+      expect(sessionCreate.inputSchema.required).toContain('sessionId');
+      expect(sessionCreate.inputSchema.required).toContain('host');
+      expect(sessionCreate.inputSchema.required).toContain('username');
+      expect(sessionCreate.inputSchema.required).toContain('privateKeyPath');
+      expect(sessionCreate.inputSchema.required).toContain('type');
+    });
+
+    it('should validate valid arguments', () => {
+      const validArgs = {
+        sessionId: 'test-session',
+        host: 'example.com',
+        username: 'user',
+        privateKeyPath: '/path/to/key',
+        type: 'interactive' as const,
+      };
+      const result = SshSessionCreateArgsSchema.safeParse(validArgs);
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate type enum', () => {
+      const invalidArgs = {
+        sessionId: 'test-session',
+        host: 'example.com',
+        username: 'user',
+        privateKeyPath: '/path/to/key',
+        type: 'invalid',
+      };
+      const result = SshSessionCreateArgsSchema.safeParse(invalidArgs);
+      expect(result.success).toBe(false);
+    });
+
+    it('should accept valid type values', () => {
+      const interactiveArgs = {
+        sessionId: 'test',
+        host: 'example.com',
+        username: 'user',
+        privateKeyPath: '/path/to/key',
+        type: 'interactive' as const,
+      };
+      expect(SshSessionCreateArgsSchema.safeParse(interactiveArgs).success).toBe(true);
+
+      const backgroundArgs = {
+        ...interactiveArgs,
+        type: 'background' as const,
+      };
+      expect(SshSessionCreateArgsSchema.safeParse(backgroundArgs).success).toBe(true);
+    });
+  });
+
+  describe('ssh_session_execute tool', () => {
+    const sessionExecute = tools.find(t => t.name === 'ssh_session_execute')!;
+
+    it('should have correct structure', () => {
+      expect(sessionExecute.name).toBe('ssh_session_execute');
+      expect(sessionExecute.inputSchema.type).toBe('object');
+    });
+
+    it('should have required parameters', () => {
+      expect(sessionExecute.inputSchema.required).toContain('sessionId');
+      expect(sessionExecute.inputSchema.required).toContain('command');
+    });
+
+    it('should validate valid arguments', () => {
+      const validArgs = {
+        sessionId: 'test-session',
+        command: 'echo "hello"',
+      };
+      const result = SshSessionExecuteArgsSchema.safeParse(validArgs);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('ssh_session_list tool', () => {
+    const sessionList = tools.find(t => t.name === 'ssh_session_list')!;
+
+    it('should have correct structure', () => {
+      expect(sessionList.name).toBe('ssh_session_list');
+      expect(sessionList.inputSchema.type).toBe('object');
+    });
+
+    it('should accept empty arguments', () => {
+      const result = SshSessionListArgsSchema.safeParse({});
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('ssh_session_close tool', () => {
+    const sessionClose = tools.find(t => t.name === 'ssh_session_close')!;
+
+    it('should have correct structure', () => {
+      expect(sessionClose.name).toBe('ssh_session_close');
+      expect(sessionClose.inputSchema.type).toBe('object');
+    });
+
+    it('should have required parameters', () => {
+      expect(sessionClose.inputSchema.required).toContain('sessionId');
+    });
+
+    it('should validate valid arguments', () => {
+      const validArgs = { sessionId: 'test-session' };
+      const result = SshSessionCloseArgsSchema.safeParse(validArgs);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('ssh_session_output tool', () => {
+    const sessionOutput = tools.find(t => t.name === 'ssh_session_output')!;
+
+    it('should have correct structure', () => {
+      expect(sessionOutput.name).toBe('ssh_session_output');
+      expect(sessionOutput.inputSchema.type).toBe('object');
+    });
+
+    it('should have required parameters', () => {
+      expect(sessionOutput.inputSchema.required).toContain('sessionId');
+    });
+
+    it('should have optional parameters', () => {
+      expect(sessionOutput.inputSchema.properties.lines).toBeDefined();
+      expect(sessionOutput.inputSchema.properties.clear).toBeDefined();
+    });
+
+    it('should validate valid arguments', () => {
+      const validArgs = {
+        sessionId: 'test-session',
+        lines: 10,
+        clear: true,
+      };
+      const result = SshSessionOutputArgsSchema.safeParse(validArgs);
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject invalid lines value', () => {
+      const invalidArgs = {
+        sessionId: 'test-session',
+        lines: -5,
+      };
+      const result = SshSessionOutputArgsSchema.safeParse(invalidArgs);
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject lines value exceeding 50000', () => {
+      const invalidArgs = {
+        sessionId: 'test-session',
+        lines: 50001,
+      };
+      const result = SshSessionOutputArgsSchema.safeParse(invalidArgs);
+      expect(result.success).toBe(false);
+    });
+
+    it('should accept lines value at maximum of 50000', () => {
+      const validArgs = {
+        sessionId: 'test-session',
+        lines: 50000,
+      };
+      const result = SshSessionOutputArgsSchema.safeParse(validArgs);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('Zod Schemas', () => {
+    it('should export SshExecuteArgsSchema', () => {
+      expect(SshExecuteArgsSchema).toBeDefined();
+    });
+
+    it('should export SshSessionCreateArgsSchema', () => {
+      expect(SshSessionCreateArgsSchema).toBeDefined();
+    });
+
+    it('should export SshSessionExecuteArgsSchema', () => {
+      expect(SshSessionExecuteArgsSchema).toBeDefined();
+    });
+
+    it('should export SshSessionListArgsSchema', () => {
+      expect(SshSessionListArgsSchema).toBeDefined();
+    });
+
+    it('should export SshSessionCloseArgsSchema', () => {
+      expect(SshSessionCloseArgsSchema).toBeDefined();
+    });
+
+    it('should export SshSessionOutputArgsSchema', () => {
+      expect(SshSessionOutputArgsSchema).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
Add complete MCP server integration with 6 SSH tools:
- ssh_execute: one-off command execution
- ssh_session_create: persistent session management
- ssh_session_execute: execute in existing session
- ssh_session_list: list active sessions
- ssh_session_close: close sessions
- ssh_session_output: retrieve buffered output (max 50k lines)

Includes Zod schemas for input validation, handler registration,
and comprehensive test coverage.
